### PR TITLE
Port fix for off-by-one of PCI resource end pointer from t-platforms 4.x kernel

### DIFF
--- a/arch/mips/include/asm/pci.h
+++ b/arch/mips/include/asm/pci.h
@@ -88,7 +88,7 @@ static inline void pci_resource_to_user(const struct pci_dev *dev, int bar,
 	phys_addr_t size = resource_size(rsrc);
 
 	*start = fixup_bigphys_addr(rsrc->start, size);
-	*end = rsrc->start + size;
+	*end = rsrc->start + size - 1;
 }
 
 /*


### PR DESCRIPTION
Vadim Vlasov found out that PCI resource end is not
calculated properly, which leads to issues in some
PCIe drivers like siliconmotion graphics drivers.